### PR TITLE
Add unidecode as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ scipy
 nltk
 networkx
 sklearn
+unidecode
 ```
 
 To pip install `pke` from github:

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -9,6 +9,7 @@ scipy
 nltk
 networkx
 sklearn
+unidecode
 ```
 
 To pip install `pke` from github:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ networkx
 numpy
 scipy
 sklearn
+unidecode

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ setup(name='pke',
       	'networkx',
       	'numpy',
       	'scipy',
-            'sklearn'
+            'sklearn',
+            'unidecode'
       ],
       package_data={'pke': ['models/*.pickle', 'models/*.gz']}
      )


### PR DESCRIPTION
Unidecode is imported and used in `pke/base.py` but was not in requirements.txt. I do not think it is a dependency of any of the listed packages since I had to explicitly install it.