### PR TITLE
Fix sklearn joblib deprecation warning

### DIFF
--- a/pke/supervised/api.py
+++ b/pke/supervised/api.py
@@ -10,7 +10,7 @@ import six
 
 from pke.base import LoadFile
 from sklearn.preprocessing import MinMaxScaler
-from sklearn.externals import joblib
+from joblib import load as load_model
 
 
 class SupervisedLoadFile(LoadFile):
@@ -58,7 +58,7 @@ class SupervisedLoadFile(LoadFile):
                                      instance + "-semeval2010.py3.pickle")
 
         # load the model
-        clf = joblib.load(model)
+        clf = load_model(model)
         # with open(model, 'rb') as f:
         #     clf = pickle.load(f)
 

--- a/pke/supervised/feature_based/kea.py
+++ b/pke/supervised/feature_based/kea.py
@@ -23,7 +23,7 @@ import string
 import logging
 
 import numpy as np
-from sklearn.externals import joblib
+from joblib import dump as dump_model
 from sklearn.naive_bayes import MultinomialNB
 
 from pke.supervised.api import SupervisedLoadFile
@@ -170,4 +170,4 @@ class Kea(SupervisedLoadFile):
 
         clf = MultinomialNB()
         clf.fit(training_instances, training_classes)
-        joblib.dump(clf, model_file)
+        dump_model(clf, model_file)

--- a/pke/supervised/feature_based/wingnus.py
+++ b/pke/supervised/feature_based/wingnus.py
@@ -20,7 +20,7 @@ import math
 import logging
 
 import numpy as np
-from sklearn.externals import joblib
+from joblib import dump as dump_model
 from sklearn.naive_bayes import MultinomialNB
 
 from pke.supervised.api import SupervisedLoadFile
@@ -253,6 +253,6 @@ class WINGNUS(SupervisedLoadFile):
 
         clf = MultinomialNB()
         clf.fit(training_instances, training_classes)
-        joblib.dump(clf, model_file)
+        dump_model(clf, model_file)
         # with open(model_file, 'wb') as f:
         #     pickle.dump(clf, f)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ scipy
 sklearn
 unidecode
 future
+joblib

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(name='pke',
-      version='1.8',
+      version='1.8.1',
       description='Python Keyphrase Extraction module',
       author='pke contributors',
       author_email='florian.boudin@univ-nantes.fr',
@@ -19,7 +19,8 @@ setup(name='pke',
           'six',
           'sklearn',
           'unidecode',
-          'future'
+          'future',
+          'joblib'
       ],
       package_data={'pke': ['models/*.pickle', 'models/*.gz']}
       )


### PR DESCRIPTION
Upon importing pke, there is a `DeprecationWarning` from sklearn:

```
lib/python3.7/site-packages/sklearn/externals/joblib/__init__.py:15: DeprecationWarning: sklearn.externals.joblib is deprecated in 0.21 and will be removed in 0.23. Please import this functionality directly from joblib, which can be installed with: pip install joblib. If this warning is raised when loading pickled models, you may need to re-serialize those models with scikit-learn 0.21+.
  warnings.warn(msg, category=DeprecationWarning)
```
Importing joblib directly is now the recommended approach:
https://scikit-learn.org/stable/modules/model_persistence.html