### PR TITLE
Adds support for custom model path

### DIFF
--- a/pke/readers.py
+++ b/pke/readers.py
@@ -70,7 +70,7 @@ class RawTextReader(Reader):
         """
 
         max_length = kwargs.get('max_length', 10**6)
-        nlp = spacy.load(self.language,
+        nlp = spacy.load(kwargs.get('model_path', self.language),
                          max_length=max_length)
         spacy_doc = nlp(text)
 
@@ -89,4 +89,3 @@ class RawTextReader(Reader):
                                       **kwargs)
 
         return doc
-


### PR DESCRIPTION
A small convenience kwarg allowing the caller to specify a custom `model_path`, in the event the model is downloaded manually or via pip and not linked into spacy's `data/en` directory.