### PR TITLE
fix compute df and lda

### DIFF
--- a/pke/utils.py
+++ b/pke/utils.py
@@ -69,7 +69,8 @@ def compute_document_frequency(input_dir,
                                normalization="stemming",
                                stoplist=None,
                                delimiter='\t',
-                               n=3):
+                               n=3,
+                               max_length=10**6):
     """Compute the n-gram document frequencies from a set of input documents. An
     extra row is added to the output file for specifying the number of
     documents from which the document frequencies were computed
@@ -107,7 +108,8 @@ def compute_document_frequency(input_dir,
         # read the input file
         doc.load_document(input=input_file,
                           language=language,
-                          normalization=normalization)
+                          normalization=normalization,
+                          max_length=max_length)
 
         # candidate selection
         doc.ngram_selection(n=n)
@@ -322,7 +324,8 @@ def compute_lda_model(input_dir,
                       n_topics=500,
                       extension="xml",
                       language="en",
-                      normalization="stemming"):
+                      normalization="stemming",
+                      max_length=10**6):
     """Compute a LDA model from a collection of documents. Latent Dirichlet
     Allocation is computed using sklearn module.
 
@@ -352,7 +355,8 @@ def compute_lda_model(input_dir,
         # read the input file
         doc.load_document(input=input_file,
                           language=language,
-                          normalization=normalization)
+                          normalization=normalization,
+                          max_length=max_length)
 
         # container for current document
         text = []


### PR DESCRIPTION
Added ```max_length``` argument to ```compute_document_frequency``` and ```compute_lda``` to avoid error: 
```
[E088] Text of length 1002263 exceeds maximum of 1000000. The v2.x parser and NER models require roughly 1GB of temporary memory per 100,000 characters in the input. This means long texts may cause memory allocation errors. If you're not using the parser or NER, it's probably safe to increase the `nlp.max_length` limit. The limit is in number of characters, so you can check whether your inputs are too long by checking `len(text)`.
```
https://github.com/boudinfl/pke/issues/68#issuecomment-564884967_