### PR TITLE
Add support for specify an already loaded spacy model

### DIFF
--- a/pke/readers.py
+++ b/pke/readers.py
@@ -67,12 +67,18 @@ class RawTextReader(Reader):
             text (str): raw text to pre-process.
             max_length (int): maximum number of characters in a single text for
                 spacy, default to 1,000,000 characters (1mb).
+            spacy_model (model): an already loaded spacy model.
         """
 
-        max_length = kwargs.get('max_length', 10**6)
-        nlp = spacy.load(self.language,
-                         max_length=max_length)
-        spacy_doc = nlp(text)
+        spacy_model = kwargs.get('spacy_model', None)
+
+        if spacy_model is not None:
+            spacy_doc = spacy_model(text)
+        else:
+            max_length = kwargs.get('max_length', 10**6)
+            nlp = spacy.load(self.language,
+                            max_length=max_length)
+            spacy_doc = nlp(text)
 
         sentences = []
         for sentence_id, sentence in enumerate(spacy_doc.sents):


### PR DESCRIPTION
Hey, thanks for sharing this project 👏 The code looks good and it allows me to try all these keyphrase extractors really easily.

I need this change because I'm tagging many chunks of text (~ 1500 paragraphs) on a batch process and this change improves the performance of the whole task _gratelly_.

I'm running two keyphrase extractors (`TextRank` and `MultipartiteRank`) over every paragraph, originally the process toke **~57min**, reusing the spacy model it takes **7min 38s**.

I know this change could have potentially other implications, but it was needed for my use case. It might also could address #101 and #102?