### PR TITLE
This code fixes a few problems when processing some datasets

### DIFF
--- a/pke/base.py
+++ b/pke/base.py
@@ -23,7 +23,34 @@ from builtins import str
 
 ISO_to_language = {'en': 'english',
                    'pt': 'portuguese',
-                   'fr': 'french'}
+                   'fr': 'french',
+                   'es': 'spanish',
+                   'it': 'italian',
+                   'nl': 'dutch',
+                   'de': 'german',
+                   'el': 'greek'}
+
+ISO_to_language_stopwords = {'ar': 'arabic',
+                'az': 'azerbaijani',
+                'da': 'danish',
+                'nl': 'dutch',
+                'en': 'english',
+                'fi': 'finnish',
+                'fr': 'french',
+                'de': 'german',
+                'el': 'greek',
+                'hu': 'hungarian',
+                'id': 'indonesian',
+                'it': 'italian',
+                'kk': 'kazakh',
+                'ne': 'nepali',
+                'nb': 'norwegian',
+                'pt': 'portuguese',
+                'ro': 'romanian',
+                'ru': 'russian',
+                'es': 'spanish',
+                'sv': 'swedish',
+                'tr': 'turkish'}
 
 escaped_punctuation = {'-lrb-': '(', '-rrb-': ')', '-lsb-': '[', '-rsb-': ']',
                        '-lcb-': '{', '-rcb-': '}'}
@@ -100,7 +127,7 @@ class LoadFile(object):
 
                 # other extensions are considered as raw text
                 else:
-                    parser = RawTextReader(language=language)
+                    parser = RawTextReader(language=kwargs['language'])
                     encoding = kwargs.get('encoding', 'utf-8')
                     with codecs.open(input, 'r', encoding=encoding) as file:
                         text = file.read()
@@ -108,7 +135,7 @@ class LoadFile(object):
 
             # if input is a string
             else:
-                parser = RawTextReader(language=language)
+                parser = RawTextReader(language=kwargs['language'])
                 doc = parser.read(text=input, **kwargs)
 
         elif getattr(input, 'read', None):
@@ -135,7 +162,10 @@ class LoadFile(object):
         self.sentences = doc.sentences
 
         # initialize the stoplist
-        self.stoplist = stopwords.words(ISO_to_language[self.language])
+        if self.language not in ISO_to_language_stopwords:
+            self.stoplist = []
+        else:
+            self.stoplist = stopwords.words(ISO_to_language_stopwords[self.language])
 
         # word normalization
         self.normalization = kwargs.get('normalization', 'stemming')

--- a/pke/base.py
+++ b/pke/base.py
@@ -185,7 +185,7 @@ class LoadFile(object):
 
         # word normalization
         self.normalization = kwargs.get('normalization', 'stemming')
-        if self.normalization == 'stemming' and self.language in ISO_to_language_stemming_SnowballStemmer::
+        if self.normalization == 'stemming' and self.language in ISO_to_language_stemming_SnowballStemmer:
             self.apply_stemming()
         elif self.normalization is None or self.language not in ISO_to_language_stemming_SnowballStemmer:
             for i, sentence in enumerate(self.sentences):

--- a/pke/base.py
+++ b/pke/base.py
@@ -52,6 +52,22 @@ ISO_to_language_stopwords = {'ar': 'arabic',
                 'sv': 'swedish',
                 'tr': 'turkish'}
 
+ISO_to_language_stemming_SnowballStemmer = {'en': 'english',
+                   'pt': 'portuguese',
+                   'fr': 'french',
+                   'es': 'spanish',
+                   'it': 'italian',
+                   'nl': 'dutch',
+                   'de': 'german',
+                   'da': 'danish',
+                   'fi': 'finnish',
+                   'da': 'danish',
+                   'hu': 'hungarian',
+                   'nb': 'norwegian',
+                   'ro': 'romanian',
+                   'ru': 'russian',
+                   'sv': 'swedish'}
+
 escaped_punctuation = {'-lrb-': '(', '-rrb-': ')', '-lsb-': '[', '-rsb-': ']',
                        '-lcb-': '{', '-rcb-': '}'}
 
@@ -169,9 +185,9 @@ class LoadFile(object):
 
         # word normalization
         self.normalization = kwargs.get('normalization', 'stemming')
-        if self.normalization == 'stemming':
+        if self.normalization == 'stemming' and self.language in ISO_to_language_stemming_SnowballStemmer::
             self.apply_stemming()
-        elif self.normalization is None:
+        elif self.normalization is None or self.language not in ISO_to_language_stemming_SnowballStemmer:
             for i, sentence in enumerate(self.sentences):
                 self.sentences[i].stems = sentence.words
 
@@ -192,7 +208,7 @@ class LoadFile(object):
             stemmer = SnowballStemmer("porter")
         else:
             # create a new instance of a porter stemmer
-            stemmer = SnowballStemmer(ISO_to_language[self.language],
+            stemmer = SnowballStemmer(ISO_to_language_stemming_SnowballStemmer[self.language],
                                       ignore_stopwords=True)
 
         # iterate throughout the sentences

--- a/pke/supervised/api.py
+++ b/pke/supervised/api.py
@@ -28,11 +28,14 @@ class SupervisedLoadFile(LoadFile):
     def feature_scaling(self):
         """ Scale features to [0,1]. """
 
-        candidates = self.instances.keys()
-        X = [self.instances[u] for u in candidates]
-        X = MinMaxScaler().fit_transform(X)
-        for i, candidate in enumerate(candidates):
-            self.instances[candidate] = X[i]
+        try:
+            candidates = self.instances.keys()
+            X = [self.instances[u] for u in candidates]
+            X = MinMaxScaler().fit_transform(X)
+            for i, candidate in enumerate(candidates):
+                self.instances[candidate] = X[i]
+        except:
+            self.instances = {}
 
     def feature_extraction(self):
         """ Skeleton for feature extraction. """

--- a/pke/utils.py
+++ b/pke/utils.py
@@ -189,8 +189,8 @@ def train_supervised_model(input_dir,
         model.__init__()
 
         # get the document id from file name
-        doc_id = '.'.join(input_file.split('/')[-1].split('.')[0:-1])
-
+        doc_id  = '.'.join(os.path.basename(input_file).split('.')[0:-1])
+        
         # load the document
         model.load_document(input=input_file,
                             language=language,

--- a/pke/utils.py
+++ b/pke/utils.py
@@ -48,8 +48,8 @@ def load_document_frequency_file(input_file,
     frequencies = {}
 
     # open the input file
-    with gzip.open(input_file, 'rt') if input_file.endswith('.gz') else \
-            codecs.open(input_file, 'rt') as f:
+    with gzip.open(input_file, 'rt', encoding="utf8") if input_file.endswith('.gz') else \
+            open(input_file, 'rt', encoding="utf8") as f:
         # read the csv file
         df_reader = csv.reader(f, delimiter=delimiter)
 


### PR DESCRIPTION
(1)
The commit from Mar 25 on Utils.py is very important as there are some encoding problems with a few datasets. This code fixes that.

(2) The commit from Mar 25 on Base.py loads stopwords from NLTK.  As for now, only stopwords from 3 different languages are being loaded. There was also an error when processing texts, other than the few languages that were initially defined in the 'ISO_to_language' dictionary. This was corrected.

(3) The commit from Mar 27 on Base.py created a dictionary for the iso languages that can be processed by the Snowball Stemmer

(4) The commit from Mar 31 on api.py: Kea is launching an exception for texts where there are no candidates (for instance, texts that are solely formed by punctuation marks or emojis). This was fixed in this code

(5) The commit on Nov 18 on utils.pt has already been fixed by Florian on his code.

I have already run this code on top of 20 datasets through all the algorithms provided by PKE and it doesn't crashes. Instead, running them through the current available PKE version leads to a few crashes particularly due to encoding problems in processing several datasets. If these commits are accepted all the problems will be fixed.
