### PR TITLE
disable unnecessary spacy pipeline components

### DIFF
--- a/pke/readers.py
+++ b/pke/readers.py
@@ -107,7 +107,8 @@ class RawTextReader(Reader):
             max_length = kwargs.get('max_length', 10**6)
             nlp = spacy.load(self.language,
                              max_length=max_length,
-                             disable=['ner', 'textcat'])
+                             disable=['ner', 'textcat', 'parser'])
+            nlp.add_pipe(nlp.create_pipe('sentencizer'))
             nlp = fix_spacy_for_french(nlp)
             spacy_doc = nlp(text)
 

--- a/pke/readers.py
+++ b/pke/readers.py
@@ -106,7 +106,8 @@ class RawTextReader(Reader):
         else:
             max_length = kwargs.get('max_length', 10**6)
             nlp = spacy.load(self.language,
-                            max_length=max_length)
+                             max_length=max_length,
+                             disable=['ner', 'textcat'])
             nlp = fix_spacy_for_french(nlp)
             spacy_doc = nlp(text)
 


### PR DESCRIPTION
Optimize `pke.readers.RawTextReader` by removing unnecessary components (`ner`, `textcat`) from `spacy` pipeline.

related issue: #118 