### PR TITLE
Improve kpminer

### DIFF
--- a/pke/unsupervised/statistical/kpminer.py
+++ b/pke/unsupervised/statistical/kpminer.py
@@ -149,4 +149,8 @@ class KPMiner(LoadFile):
             # compute the idf score
             idf = math.log(N / candidate_df, 2)
 
-            self.weights[k] = len(v.surface_forms) * B * idf
+            if len(v.lexical_form) == 1:
+                # If single word candidate do not apply boosting factor
+                self.weights[k] = len(v.surface_forms) * idf
+            else:
+                 self.weights[k] = len(v.surface_forms) * B * idf


### PR DESCRIPTION
Changes KPMiner according to #117 .
Running `pytest` showed 1 error linked to `test_expandrank_candidate_weighting` which is expected.