### PR TITLE
Fix yake

### DIFF
--- a/pke/unsupervised/statistical/yake.py
+++ b/pke/unsupervised/statistical/yake.py
@@ -364,13 +364,16 @@ class YAKE(LoadFile):
                     sum_ = 0.
                     for j, token in enumerate(tokens):
                         if self.features[token]['isstop']:
-                            term_left = tokens[j-1]
-                            term_right = tokens[j+1]
                             term_stop = token
-                            prob_t1 = self.contexts[term_left][1].count(
-                                term_stop) / self.features[term_left]['TF']
-                            prob_t2 = self.contexts[term_stop][0].count(
-                                term_right) / self.features[term_right]['TF']
+                            prob_t1 = prob_t2 = 0
+                            if j - 1 >= 0:
+                                term_left = tokens[j-1]
+                                prob_t1 = self.contexts[term_left][1].count(
+                                    term_stop) / self.features[term_left]['TF']
+                            if j + 1 < len(tokens):
+                                term_right = tokens[j+1]
+                                prob_t2 = self.contexts[term_stop][0].count(
+                                    term_right) / self.features[term_right]['TF']
 
                             prob = prob_t1 * prob_t2
                             prod_ *= (1 + (1 - prob))
@@ -378,7 +381,11 @@ class YAKE(LoadFile):
                         else:
                             prod_ *= self.features[token]['weight']
                             sum_ += self.features[token]['weight']
-
+                    if sum_ == -1:
+                        # The candidate is a one token stopword at the start or
+                        #  the end of the sentence
+                        # Setting sum_ to -1+eps so 1+sum_ != 0
+                        sum_ = -0.99999999999
                     self.weights[candidate] = prod_
                     self.weights[candidate] /= TF * (1 + sum_)
                     self.surface_to_lexical[candidate] = k


### PR DESCRIPTION
Fixes #133.
In YAKE when the candidate is a stopword and occur at the beginning or at the end of a sentence, an IndexError is thrown.
This is because we try to acces the previous or next token (which might not exist) in order to compute the probability of the candidate.
According to [LIAAD/yake](https://github.com/LIAAD/yake/blob/2c9fedbe0e3195a273a3c3daef3d41d4d7c5b3b3/yake/datarepresentation.py#L264) I set the default probability to 0, and only compute the probability if available.
This results in a ZeroDevisionError because when `self.weights[candidate] /= TF * (1 + sum_)` is computed, `sum_` is -1 and thus `(1 + sum_)` is 0.
To fix this error, I set `sum_` to `-1 + eps` so the resulting weight is very large, in this model a large weight implies a low probability of the candidate being a keyphrase.