### PR TITLE
Fixes reported by #106

### DIFF
--- a/examples/training_and_testing_a_kea_model/train.py
+++ b/examples/training_and_testing_a_kea_model/train.py
@@ -8,7 +8,7 @@ import pke
 logging.basicConfig(level=logging.INFO)
 
 # path to the collection of documents
-input_dir = 'train/'
+input_dir = 'train' + os.sep
 
 # path to the reference file
 reference_file = "gold-annotation.txt"

--- a/pke/base.py
+++ b/pke/base.py
@@ -53,10 +53,10 @@ def get_stopwords(lang):
         return stopwords.words(lang)
     except KeyError:
         if PRINT_NO_STWO_WARNING[lang]:
-            logging.warning('No default stopwords for \'{}\' language.'.format(lang))
-            logging.warning('Please provide stoplist if willing to use stopwords.')
-            logging.warning('Check for nltk\'s `stopwords` corpora update using '
-                            '`python -m nltk.downloader`')
+            logging.warning('No stopwords for \'{}\' language.'.format(lang))
+            logging.warning(
+                'Please provide custom stoplist if willing to use stopwords. Or '
+                'update nltk\'s `stopwords` corpora using `nltk.download(\'stopwords\')`')
             PRINT_NO_STWO_WARNING[lang] = False
         return []
 

--- a/pke/base.py
+++ b/pke/base.py
@@ -25,17 +25,7 @@ from builtins import str
 
 
 # The language management should be in `pke.utils` but it would create a circular import.
-# Manually created from https://spacy.io/models the 04/05/2020
-lang_spacy = {
-    'en': 'english',
-    'pt': 'portuguese',
-    'fr': 'french',
-    'es': 'spanish',
-    'it': 'italian',
-    'nl': 'dutch',
-    'de': 'german',
-    'el': 'greek'
-}
+
 get_alpha_2 = lambda l: langcodes.find(l).language
 
 lang_stopwords = {get_alpha_2(l): l for l in stopwords._fileids}

--- a/pke/supervised/api.py
+++ b/pke/supervised/api.py
@@ -74,6 +74,8 @@ class SupervisedLoadFile(LoadFile):
 
     def candidate_weighting(self):
         """ Extract features and classify candidates with default parameters."""
+        if not self.candidates:
+            return
 
         self.feature_extraction()
         self.classify_candidates()

--- a/pke/supervised/feature_based/kea.py
+++ b/pke/supervised/feature_based/kea.py
@@ -154,6 +154,8 @@ class Kea(SupervisedLoadFile):
             df (dict): document frequencies, the number of documents should
                     be specified using the "--NB_DOC--" key.
         """
+        if not self.candidates:
+            return
 
         self.feature_extraction(df=df)
         self.classify_candidates(model=model_file)

--- a/pke/supervised/feature_based/wingnus.py
+++ b/pke/supervised/feature_based/wingnus.py
@@ -237,6 +237,8 @@ class WINGNUS(SupervisedLoadFile):
             df (dict): document frequencies, the number of documents should
                     be specified using the "--NB_DOC--" key.
         """
+        if not self.candidates:
+            return
 
         self.feature_extraction(df=df)
         self.classify_candidates(model=model_file)

--- a/pke/unsupervised/graph_based/multipartiterank.py
+++ b/pke/unsupervised/graph_based/multipartiterank.py
@@ -210,6 +210,8 @@ class MultipartiteRank(TopicRank):
                 alpha (float): hyper-parameter that controls the strength of the
                     weight adjustment, defaults to 1.1.
         """
+        if not self.candidates:
+            return
 
         # cluster the candidates
         self.topic_clustering(threshold=threshold, method=method)

--- a/pke/unsupervised/graph_based/single_tpr.py
+++ b/pke/unsupervised/graph_based/single_tpr.py
@@ -17,18 +17,16 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import gzip
 import os
-import pickle
 import logging
 
 import networkx as nx
 import numpy as np
 import six
 from scipy.spatial.distance import cosine
-from sklearn.decomposition import LatentDirichletAllocation
 from sklearn.feature_extraction.text import CountVectorizer
 
+import pke.utils
 from pke.unsupervised import SingleRank
 
 
@@ -137,9 +135,6 @@ class TopicalPageRank(SingleRank):
         self.build_word_graph(window=window,
                               pos=pos)
 
-        # create a blank model
-        model = LatentDirichletAllocation()
-
         # set the default LDA model if none provided
         if lda_model is None:
             if six.PY2:
@@ -151,11 +146,7 @@ class TopicalPageRank(SingleRank):
             logging.warning('LDA model is hard coded to {}'.format(lda_model))
 
         # load parameters from file
-        with gzip.open(lda_model, 'rb') as f:
-            (dictionary,
-             model.components_,
-             model.exp_dirichlet_component_,
-             model.doc_topic_prior_) = pickle.load(f)
+        dictionary, model = pke.utils.load_lda_model(lda_model)
 
         # build the document representation
         doc = []

--- a/pke/unsupervised/graph_based/single_tpr.py
+++ b/pke/unsupervised/graph_based/single_tpr.py
@@ -121,6 +121,8 @@ class TopicalPageRank(SingleRank):
             normalized (False): normalize keyphrase score by their length,
                 defaults to False.
         """
+        if not self.candidates:
+            return
 
         if pos is None:
             pos = {'NOUN', 'PROPN', 'ADJ'}

--- a/pke/unsupervised/graph_based/topicrank.py
+++ b/pke/unsupervised/graph_based/topicrank.py
@@ -198,6 +198,8 @@ class TopicRank(LoadFile):
                 ties).
 
         """
+        if not self.candidates:
+            return
 
         # cluster the candidates
         self.topic_clustering(threshold=threshold, method=method)

--- a/pke/unsupervised/statistical/yake.py
+++ b/pke/unsupervised/statistical/yake.py
@@ -332,6 +332,8 @@ class YAKE(LoadFile):
             window (int): the size in words of the window used for computing
                 co-occurrence counts, defaults to 2.
         """
+        if not self.candidates:
+            return
 
         # build the vocabulary
         self._vocabulary_building(use_stems=use_stems)

--- a/pke/utils.py
+++ b/pke/utils.py
@@ -98,7 +98,7 @@ def compute_document_frequency(input_dir,
     nb_documents = 0
 
     # loop through the documents
-    for input_file in glob.iglob(input_dir + '/*.' + extension):
+    for input_file in glob.iglob(input_dir + os.sep + '*.' + extension):
 
         #logging.info('reading file {}'.format(input_file))
 
@@ -196,7 +196,7 @@ def train_supervised_model(input_dir,
     sizes = []
 
     # get the input files from the input directory
-    for input_file in glob.iglob(input_dir + '/*.' + extension):
+    for input_file in glob.iglob(input_dir + os.sep + '*.' + extension):
 
         logging.info('reading file {}'.format(input_file))
 
@@ -345,7 +345,7 @@ def compute_lda_model(input_dir,
     texts = []
 
     # loop throught the documents
-    for input_file in glob.iglob(input_dir + '/*.' + extension):
+    for input_file in glob.iglob(input_dir + os.sep + '*.' + extension):
 
         logging.info('reading file {}'.format(input_file))
 
@@ -491,8 +491,8 @@ def compute_pairwise_similarity_matrix(input_dir,
     if collection_dir is not None:
 
         # loop throught the documents in the collection
-        for input_file in glob.iglob(collection_dir + '/*.' + extension):
-
+        for input_file in glob.iglob(
+                collection_dir + os.sep + '*.' + extension):
             logging.info('Reading file from {}'.format(input_file))
 
             # initialize document vector
@@ -509,7 +509,7 @@ def compute_pairwise_similarity_matrix(input_dir,
         N += 1
 
     # loop throught the documents in the input directory
-    for input_file in glob.iglob(input_dir + '/*.' + extension):
+    for input_file in glob.iglob(input_dir + os.sep + '*.' + extension):
 
         logging.info('Reading file from {}'.format(input_file))
 

--- a/pke/utils.py
+++ b/pke/utils.py
@@ -20,14 +20,10 @@ import logging
 
 from collections import defaultdict
 
-from pke.base import LoadFile
-from pke.base import ISO_to_language
+from pke.base import LoadFile, get_stopwords, get_stemmer_func
 
 from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.decomposition import LatentDirichletAllocation
-
-from nltk.stem.snowball import SnowballStemmer
-from nltk.corpus import stopwords
 
 
 def load_document_frequency_file(input_file,
@@ -315,14 +311,11 @@ def load_references(input_file,
         if normalize_reference:
 
             # initialize stemmer
-            stemmer = SnowballStemmer("porter")
-            if language != 'en':
-                stemmer = SnowballStemmer(ISO_to_language[language],
-                                          ignore_stopwords=True)
+            stem = get_stemmer_func(language)
 
             for doc_id in references:
                 for i, keyphrase in enumerate(references[doc_id]):
-                    stems = [stemmer.stem(w) for w in keyphrase.split()]
+                    stems = [stem(w) for w in keyphrase.split()]
                     references[doc_id][i] = ' '.join(stems)
 
     return references
@@ -407,7 +400,7 @@ def compute_lda_model(input_dir,
     # get the stoplist from nltk because CountVectorizer only contains english
     # stopwords atm
     tf_vectorizer = CountVectorizer(
-        stop_words=stopwords.words(ISO_to_language[language]))
+        stop_words=get_stopwords(language))
     tf = tf_vectorizer.fit_transform(texts)
 
     # extract vocabulary

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ nltk
 networkx
 numpy
 scipy
-scikit-learn
+scikit-learn<=0.22
 unidecode
 future
 joblib
+langcodes

--- a/tests/test_embedrank.py
+++ b/tests/test_embedrank.py
@@ -3,9 +3,10 @@
 
 from __future__ import unicode_literals
 
-import mock
+import os
 import sys
 
+import mock
 import pke
 
 text = u"Compatibility of systems of linear constraints over the set of natural\
@@ -23,7 +24,7 @@ pos = {'NOUN', 'PROPN', 'ADJ'}
 def test_embedrank_candidate_weighting():
     """Test SingleRank candidate weighting method."""
     extractor = pke.unsupervised.EmbedRank(
-        embedding_path='tests/data/inspec_sent2vec.bin')
+        embedding_path=os.path.join('tests', 'data', 'inspec_sent2vec.bin'))
     extractor.load_document(input=text)
     extractor.candidate_selection()
     extractor.candidate_weighting(l=1)

--- a/tests/test_expandrank.py
+++ b/tests/test_expandrank.py
@@ -41,18 +41,6 @@ def test_singlerank_candidate_weighting():
     keyphrases = [k for k, s in extractor.get_n_best(n=10)]
     print(keyphrases)
 
-def load_pairwise_similarities(path):
-    """Load the pairwise similarities for ExpandRank."""
-
-    pairwise_sim = defaultdict(list)
-    with gzip.open(path, 'rb') as f:
-        lines = f.readlines()
-        for line in lines:
-            cols = line.decode('utf-8').strip().split()
-            bisect.insort(pairwise_sim[cols[0].split("/")[-1]], (float(cols[2]), cols[1].split("/")[-1]))
-            bisect.insort(pairwise_sim[cols[1].split("/")[-1]], (float(cols[2]), cols[0].split("/")[-1]))
-    return pairwise_sim
-
 
 if __name__ == '__main__':
     """ You will first need to perform the function compute_document_frequency(input_dir=input_dir, ...)
@@ -66,7 +54,7 @@ if __name__ == '__main__':
 
     # hyperparameters neighbor numbers
     n_expanded = 1
-    pairwise = load_pairwise_similarities(os.path.join('test', 'data', 'Output.gz'))
+    pairwise = pke.utils.load_pairwise_similarities(os.path.join('test', 'data', 'Output.gz'))
     test_expandrank_candidate_selection()
     expanded_documents = [(v, u) for u, v in pairwise[os.path.basename(input_file)][-n_expanded:]]
     test_expandrank_candidate_weighting(expanded_documents)

--- a/tests/test_expandrank.py
+++ b/tests/test_expandrank.py
@@ -3,12 +3,13 @@
 
 from __future__ import unicode_literals
 
+import os
 import pke
 from collections import defaultdict
 import gzip
 import bisect
 
-input_file = 'data/FT923-5089.xml'
+input_file = os.path.join('test', 'data', 'FT923-5089.xml')
 pos = {'NOUN', 'PROPN', 'ADJ'}
 
 
@@ -65,8 +66,8 @@ if __name__ == '__main__':
 
     # hyperparameters neighbor numbers
     n_expanded = 1
-    pairwise = load_pairwise_similarities("data/Output.gz")
+    pairwise = load_pairwise_similarities(os.path.join('test', 'data', 'Output.gz'))
     test_expandrank_candidate_selection()
-    expanded_documents = [(v, u) for u, v in pairwise[input_file.split("/")[-1]][-n_expanded:]]
+    expanded_documents = [(v, u) for u, v in pairwise[os.path.basename(input_file)][-n_expanded:]]
     test_expandrank_candidate_weighting(expanded_documents)
     test_singlerank_candidate_weighting()

--- a/tests/test_firstphrases.py
+++ b/tests/test_firstphrases.py
@@ -3,10 +3,11 @@
 
 from __future__ import unicode_literals
 
+import os
 import pke
 
 valid_pos = {'NOUN', 'PROPN', 'ADJ'}
-test_file = 'tests/data/1939.xml'
+test_file = os.path.join('tests', 'data', '1939.xml')
 
 
 def test_firstphrases_candidate_selection():

--- a/tests/test_positionrank.py
+++ b/tests/test_positionrank.py
@@ -3,9 +3,10 @@
 
 from __future__ import unicode_literals
 
+import os
 import pke
 
-test_file = 'tests/data/1939.xml'
+test_file = os.path.join('tests', 'data', '1939.xml')
 
 grammar = "NP: {<ADJ>*<NOUN|PROPN>+}"
 pos = {'NOUN', 'PROPN', 'ADJ'}

--- a/tests/test_reading.py
+++ b/tests/test_reading.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import os
 import pke
 import codecs
 
 model = pke.unsupervised.TopicRank
 
-xml_test_file = 'tests/data/1939.xml'
-raw_test_file = 'tests/data/1939.txt'
+data_path = os.path.join('tests', 'data')
+xml_test_file = data_path + os.sep + '1939.xml'
+raw_test_file = data_path + os.sep + '1939.txt'
 
 
 def test_reading():

--- a/tests/test_running.py
+++ b/tests/test_running.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import os
 from pke.unsupervised import (
     TopicRank, SingleRank,
     MultipartiteRank, PositionRank,
@@ -10,8 +11,7 @@ from pke.unsupervised import (
 )
 from pke.supervised import Kea, WINGNUS
 
-test_file = 'tests/data/1939.xml'
-
+test_file = os.path.join('tests', 'data', '1939.xml')
 
 def test_unsupervised_run():
     def test(model, file):

--- a/tests/test_singlerank.py
+++ b/tests/test_singlerank.py
@@ -3,9 +3,10 @@
 
 from __future__ import unicode_literals
 
+import os
 import pke
 
-test_file = 'tests/data/1939.xml'
+test_file = os.path.join('tests', 'data', '1939.xml')
 pos = {'NOUN', 'PROPN', 'ADJ'}
 
 

--- a/tests/test_singletpr.py
+++ b/tests/test_singletpr.py
@@ -3,9 +3,10 @@
 
 from __future__ import unicode_literals
 
+import os
 import pke
 
-test_file = 'tests/data/1939.xml'
+test_file = os.path.join('tests', 'data', '1939.xml')
 grammar = "NP: {<ADJ>*<NOUN|PROPN>+}"
 pos = {'NOUN', 'PROPN', 'ADJ'}
 

--- a/tests/test_textrank.py
+++ b/tests/test_textrank.py
@@ -3,9 +3,10 @@
 
 from __future__ import unicode_literals
 
+import os
 import pke
 
-test_file = 'tests/data/1939.xml'
+test_file = os.path.join('tests', 'data', '1939.xml')
 pos = {'NOUN', 'PROPN', 'ADJ'}
 
 

--- a/tests/test_tfidf.py
+++ b/tests/test_tfidf.py
@@ -3,9 +3,10 @@
 
 from __future__ import unicode_literals
 
+import os
 import pke
 
-test_file = 'tests/data/1939.xml'
+test_file = os.path.join('tests', 'data', '1939.xml')
 
 
 def test_tfidf_candidate_selection():

--- a/tests/test_topicrank.py
+++ b/tests/test_topicrank.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import os
 import pke
 
 valid_pos = {'NOUN', 'PROPN', 'ADJ'}
-test_file = 'tests/data/1939.xml'
+test_file = os.path.join('tests', 'data', '1939.xml')
 
 
 def test_topicrank_candidate_selection():


### PR DESCRIPTION
- Using `pke` with languages where *spacy* or *stemming* or *stopwords* aren't available will fall back to not using the resource instead of crashing.
- Replaced hard coded `/` by `os.sep`.
- Prevent exceptions to be thrown when there are no candidates.
- Ensuring encoding is consistent between creating and loading resource.
- Added `encoding` parameter to specify documents encoding (defaults to systems default encoding).
- Moved `load_pairwise_similarities` and `load_lda_model` to `utils.py`.