### PR TITLE
Fix bug in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ setup(name='pke',
           'sklearn',
           'unidecode',
           'future',
-          'joblib'
+          'joblib',
+          'langcodes'
       ],
       package_data={'pke': ['models/*.pickle', 'models/*.gz']}
       )


### PR DESCRIPTION
New requirement was added into requirements.txt but not to setup.py. The pip install is successful, but importing pke throws ModuleNotFoundError: No module named 'langcodes'