### PR TITLE
Fix 0 division error with overlapping candidates

### DIFF
--- a/pke/unsupervised/graph_based/multipartiterank.py
+++ b/pke/unsupervised/graph_based/multipartiterank.py
@@ -50,9 +50,9 @@ class MultipartiteRank(TopicRank):
         stoplist += stopwords.words('english')
         extractor.candidate_selection(pos=pos, stoplist=stoplist)
 
-        # 4. build the Multipartite graph and rank candidates using random walk,
-        #    alpha controls the weight adjustment mechanism, see TopicRank for
-        #    threshold/method parameters.
+        # 4. build the Multipartite graph and rank candidates using random
+        #    walk, alpha controls the weight adjustment mechanism, see
+        #    TopicRank for threshold/method parameters.
         extractor.candidate_weighting(alpha=1.1,
                                       threshold=0.74,
                                       method='average')
@@ -82,7 +82,7 @@ class MultipartiteRank(TopicRank):
             Args:
                 threshold (float): the minimum similarity for clustering,
                     defaults to 0.74, i.e. more than 1/4 of stem overlap
-                    similarity. 
+                    similarity.
                 method (str): the linkage method, defaults to average.
         """
 
@@ -125,7 +125,8 @@ class MultipartiteRank(TopicRank):
         for node_i, node_j in combinations(self.candidates.keys(), 2):
 
             # discard intra-topic edges
-            if self.topic_identifiers[node_i] == self.topic_identifiers[node_j]:
+            if self.topic_identifiers[node_i] \
+               == self.topic_identifiers[node_j]:
                 continue
 
             weights = []
@@ -152,7 +153,7 @@ class MultipartiteRank(TopicRank):
 
                     weights.append(1.0 / gap)
 
-            # add weighted edges 
+            # add weighted edges
             if weights:
                 # node_i -> node_j
                 self.graph.add_edge(node_i, node_j, weight=sum(weights))
@@ -163,8 +164,8 @@ class MultipartiteRank(TopicRank):
         """ Adjust edge weights for boosting some candidates.
 
             Args:
-                alpha (float): hyper-parameter that controls the strength of the
-                    weight adjustment, defaults to 1.1.
+                alpha (float): hyper-parameter that controls the strength of
+                    the weight adjustment, defaults to 1.1.
         """
 
         # weighted_edges = defaultdict(list)
@@ -204,7 +205,8 @@ class MultipartiteRank(TopicRank):
             node_i, node_j = nodes
             position_i = 1.0 / (1 + self.candidates[node_i].offsets[0])
             position_i = math.exp(position_i)
-            self.graph[node_j][node_i]['weight'] += (boosters * alpha * position_i)
+            self.graph[node_j][node_i]['weight'] += (
+                boosters * alpha * position_i)
 
     def candidate_weighting(self,
                             threshold=0.74,
@@ -216,8 +218,8 @@ class MultipartiteRank(TopicRank):
                 threshold (float): the minimum similarity for clustering,
                     defaults to 0.25.
                 method (str): the linkage method, defaults to average.
-                alpha (float): hyper-parameter that controls the strength of the
-                    weight adjustment, defaults to 1.1.
+                alpha (float): hyper-parameter that controls the strength of
+                    the weight adjustment, defaults to 1.1.
         """
         if not self.candidates:
             return

--- a/pke/unsupervised/graph_based/topicrank.py
+++ b/pke/unsupervised/graph_based/topicrank.py
@@ -97,9 +97,11 @@ class TopicRank(LoadFile):
             stoplist = self.stoplist
 
         # filter candidates containing stopwords or punctuation marks
-        self.candidate_filtering(stoplist=list(string.punctuation) +
-                                          ['-lrb-', '-rrb-', '-lcb-', '-rcb-', '-lsb-', '-rsb-'] +
-                                          stoplist)
+        self.candidate_filtering(stoplist=(
+            list(string.punctuation)
+            + ['-lrb-', '-rrb-', '-lcb-', '-rcb-', '-lsb-', '-rsb-']
+            + stoplist
+        ))
 
     def vectorize_candidates(self):
         """Vectorize the keyphrase candidates.
@@ -206,9 +208,9 @@ class TopicRank(LoadFile):
                 to 0.74.
             method (str): the linkage method, defaults to average.
             heuristic (str): the heuristic for selecting the best candidate for
-                each topic, defaults to first occurring candidate. Other options
-                are 'frequent' (most frequent candidate, position is used for
-                ties).
+                each topic, defaults to first occurring candidate. Other
+                options are 'frequent' (most frequent candidate, position is
+                used for ties).
 
         """
         if not self.candidates:


### PR DESCRIPTION
Fixes #176 

The test I used to verify my code was:
```python
import pke

e = pke.unsupervised.MultipartiteRank()
e.load_document('a b c d e f g')
tmp_cand = ['b', 'c', 'd', 'e']
e.add_candidate(tmp_cand, tmp_cand, tmp_cand, 1, 0)
tmp_cand = ['a', 'b']
e.add_candidate(tmp_cand, tmp_cand, tmp_cand, 0, 0)

e.candidate_weighting()
e.get_n_best()
```

`ab` and `bcde` overlap but they aren't in the same topic. Their gap is `abs(0-1) - (len('ab') - 1) = 1 - (2 - 1) = 0` which results in ZeroDivisionException.
With this branch, if the keyphrase which offset is bigger begins inside the first keyphrase, then the gap is 1.