### PR TITLE
添加"zh": "chinese"

### DIFF
--- a/pke/lang.py
+++ b/pke/lang.py
@@ -28,7 +28,8 @@ langcodes = {
        "ru": "russian",
        "sp": "spanish",
        "sw": "swedish",
-       "ja": "japanese"
+       "ja": "japanese",
+       "zh": "chinese"
 }
 
 stopwords = {}


### PR DESCRIPTION
在lang.py添加"zh": "chinese"，支持自动加载中文停用词，解决candidate_filtering的421行；stoplist为none的情况