### PR TITLE
Fix for German and Polish stopwords

### DIFF
--- a/pke/lang.py
+++ b/pke/lang.py
@@ -19,7 +19,7 @@ langcodes = {
        "en": "english",
        "fi": "finnish",
        "fr": "french",
-       "ge": "german",
+       "de": "german",
        "hu": "hungarian",
        "it": "italian",
        "no": "norwegian",
@@ -28,7 +28,8 @@ langcodes = {
        "ru": "russian",
        "sp": "spanish",
        "sw": "swedish",
-       "ja": "japanese"
+       "ja": "japanese",
+       "pl": "polish",
 }
 
 stopwords = {}


### PR DESCRIPTION
I fixed German language code ("ge" -> "de") and added Polish, so that extraction won't break in `base.py:423 in candidate_filtering` with `TypeError: 'NoneType' object is not iterable`