### PR TITLE
Remove keyword argument `G` from `nx.pagerank()` in PositionRank for networkx>3.0

### DIFF
--- a/pke/unsupervised/graph_based/positionrank.py
+++ b/pke/unsupervised/graph_based/positionrank.py
@@ -168,7 +168,7 @@ class PositionRank(SingleRank):
             self.positions[word] /= norm
 
         # compute the word scores using biased random walk
-        w = nx.pagerank(G=self.graph,
+        w = nx.pagerank(self.graph,
                         alpha=0.85,
                         tol=0.0001,
                         personalization=self.positions,


### PR DESCRIPTION
Following https://github.com/networkx/networkx/issues/6458, I remove keyword argument `G` from `nx.pagerank()` in PositionRank. 
fixes issue #221
