### PR TITLE
Consolidate lang usage in pke

### DIFF
--- a/pke/base.py
+++ b/pke/base.py
@@ -84,9 +84,9 @@ class LoadFile(object):
             try:
                 self.stoplist = stopwords[self.language]
             except KeyError:
-                logging.warning('No stoplist available for \'{}\' language.'.format(self.language))
-                logging.warning('Set `stoplist` to `[]` or a custom stoplist to suppress this warning.')
-                self.stoplist = set()
+                logging.warning('No stoplist available in pke for \'{}\' language.'.format(self.language))
+                # logging.warning('Set `stoplist` to `[]` or a custom stoplist to suppress this warning.')
+                self.stoplist = []
 
         # check whether input is a spacy doc object instance
         if isinstance(input, spacy.tokens.doc.Doc):
@@ -101,9 +101,7 @@ class LoadFile(object):
             parser = PreprocessedReader()
             sents = parser.read(list_of_sentence_tuples=input)
         else:
-            logging.error('Cannot process input. It is neither a spacy doc or a string: {}'.format(type(input)))
-            # TODO raise TypeError('Cannot process input. It is neither a spacy doc, a string or a list of tuple: {}'.format(type(input)))) ?
-            return
+            raise TypeError('Cannot process input. It is neither a spacy doc, a string or a list of list of tuple: {}'.format(type(input)))
 
         # populate the sentences
         self.sentences = sents
@@ -117,7 +115,7 @@ class LoadFile(object):
                     langcode = 'porter'
                 stemmer = SnowballStemmer(langcode)
             except ValueError:
-                logging.error('No stemmer available for \'{}\' language -> fall back to porter.'.format(self.language))
+                logging.warning('No stemmer available in pke for \'{}\' language -> falling back to porter stemmer.'.format(self.language))
                 stemmer = SnowballStemmer("porter")
 
             # populate Sentence.stems

--- a/pke/base.py
+++ b/pke/base.py
@@ -78,10 +78,15 @@ class LoadFile(object):
         self.normalization = normalization
 
         # initialize the stoplist
-        if stoplist:
+        if stoplist is not None:
             self.stoplist = stoplist
         else:
-            self.stoplist = stopwords.get(self.language)
+            try:
+                self.stoplist = stopwords[self.language]
+            except KeyError:
+                logging.warning('No stoplist available for \'{}\' language.'.format(self.language))
+                logging.warning('Set `stoplist` to `[]` or a custom stoplist to suppress this warning.')
+                self.stoplist = set()
 
         # check whether input is a spacy doc object instance
         if isinstance(input, spacy.tokens.doc.Doc):

--- a/pke/lang.py
+++ b/pke/lang.py
@@ -12,23 +12,30 @@ Langcodes.
 
 import importlib
 
+# This dictionnary holds only languages supported by `pke`.
+# Supported languages need a stemmer and a spacy model.
+
+# This dictionnary maps spacy's langcode to stemmer language
+#  (ordered by language name).
+# The list of languages was obtained using:
+#  `nltk.stem.SnowballStemmer.languages`
+
 langcodes = {
-       "ar": "arabic",
-       "da": "danish",
-       "du": "dutch",
-       "en": "english",
-       "fi": "finnish",
-       "fr": "french",
-       "ge": "german",
-       "hu": "hungarian",
-       "it": "italian",
-       "no": "norwegian",
-       "pt": "portuguese",
-       "ro": "romanian",
-       "ru": "russian",
-       "sp": "spanish",
-       "sw": "swedish",
-       "ja": "japanese"
+    # "ar": "arabic", # no spacy model yet ;)
+    "da": "danish",
+    "nl": "dutch",
+    "en": "english",
+    "fi": "finnish",
+    "fr": "french",
+    "de": "german",
+    # "hu": "hungarian", # no spacy model yet ;)
+    "it": "italian",
+    "nb": "norwegian",
+    "pt": "portuguese",
+    "ro": "romanian",
+    "ru": "russian",
+    "es": "spanish",
+    "sv": "swedish",
 }
 
 stopwords = {}

--- a/pke/readers.py
+++ b/pke/readers.py
@@ -83,9 +83,11 @@ class RawTextReader(Reader):
 
             # stop execution is no model is available
             else:
-                logging.error('No spacy model for \'{}\' language.'.format(self.language))
-                logging.error('A list of available spacy models is available at https://spacy.io/models.')
-                return
+                excp_msg = 'No downloaded spacy model for \'{}\' language.'.format(self.language)
+                excp_msg += '\nA list of downloadable spacy models is available at https://spacy.io/models.'
+                excp_msg += '\nAlternatively, preprocess your document as a list of sentence tuple (word, pos), such as:'
+                excp_msg += "\n\t[[('The', 'DET'), ('brown', 'ADJ'), ('fox', 'NOUN'), ('.', 'PUNCT')]]"
+                raise Exception(excp_msg)
 
             # add the sentence splitter
             nlp.add_pipe('sentencizer')

--- a/pke/readers.py
+++ b/pke/readers.py
@@ -54,6 +54,9 @@ class RawTextReader(Reader):
         if language is None:
             self.language = 'en'
 
+        if len(self.language) != 2:
+            raise ValueError('`language` is \'{}\', but should be an iso2 language code (\'en\' instead of \'english\')'.format(self.language))
+
     def read(self, text, spacy_model=None):
         """Read the input file and use spacy to pre-process.
 


### PR DESCRIPTION
- Fixed: Trying to load non available stopwords raises `TypeError`
- Fixed: Some langcodes in `pke.lang.langcodes` were not accurate (#193, #215, #216, #219)
- Clarified what languages are supported in pke (#191), only the one that have a `nltk.stem.SnowballStemmer` and a spacy model.
- Added exception to prevent using a keyword extractor that wasn't properly initialized.

There are 3 cases when using pke regarding to language used:
- spacy model and stemmer available
```bash
python -m spacy download fr_core_news_sm
python << BEGIN
import pke
e = pke.unsupervised.PositionRank()
e.load_document("Ga bu zo meu", language='fr')
BEGIN
```
- spacy model but **no** stemmer available : falls back to porter stemmer, does not use stopwords
```bash
python -m spacy download pl_core_news_sm
python << BEGIN
import pke
e = pke.unsupervised.PositionRank()
e.load_document("Ga bu zo meu", language='pl')
# WARNING:root:No stoplist available in pke for 'pl' language.
# WARNING:root:No stemmer available in pke for 'pl' language -> falling back to porter stemmer.
BEGIN
```
- **no** spacy model available: preprocessing needs to happen outside of pke
```bash
python << BEGIN
import pke
e = pke.unsupervised.PositionRank()
doc = [[('Ga', 'DET'), ('bu', 'ADJ'), ('zo', 'NOUN'), ('meu', 'VERB')]]
e.load_document(doc, language='ug')
# WARNING:root:No stoplist available in pke for 'ug' language.
# WARNING:root:No stemmer available in pke for 'ug' language -> falling back to porter stemmer.
BEGIN
```